### PR TITLE
Set QOS inside consumer loop

### DIFF
--- a/pika_multithreaded/clients.py
+++ b/pika_multithreaded/clients.py
@@ -196,12 +196,12 @@ class AmqpClient:
             self.queue_declare(queue, durable=True)
         keep_consuming = True
         self.user_consumer_callback = callback_function
-        # Set QOS prefetch count. Now that this is multi-threaded, we can now control how many
-        # messages we process in parallel by simply increasing this number.
-        self.channel.basic_qos(prefetch_count=qos_count)
         while keep_consuming:
             self.logger.debug(f"Connecting to queue {queue}...")
             try:
+                # Set QOS prefetch count. Now that this is multi-threaded, we can now control how
+                # many messages we process in parallel by simply increasing this number.
+                self.channel.basic_qos(prefetch_count=qos_count)
                 # Consume the queue
                 if consumer_tag:
                     self.consumer_tag = consumer_tag

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open("README.md", "r") as file:
 
 setup(
     name='pika-multithreaded',
-    version='1.0.0',
+    version='1.0.1',
     author='Nimbis Services',
     author_email='info@nimbisservics.com',
     description='A project that enables multithreading support for the Pika package',


### PR DESCRIPTION
When we need to reconnect, it would reconnect the consumer without the
QOS being set. This is because the QOS is not being set inside the main
loop. So when that loop returns to the beginning, we get a consumer with
no QOS being set. This moves the QOS to being set inside the main loop
so if we do return to the beginning of the loop, we also set the QOS
again as well.