### PR TITLE
Fix network resiliency

### DIFF
--- a/examples/consume_test.py
+++ b/examples/consume_test.py
@@ -1,0 +1,51 @@
+import logging
+from pika_multithreaded.clients import AmqpClient
+
+
+def new_amqp_client():
+    return AmqpClient(
+        url=BROKER_URL)
+
+
+def receive_message(amqp_client, _, method, properties, body):
+    logger.debug("****** Message Received! ******")
+    logger.debug(f"Channel: {amqp_client.channel}")
+    logger.debug(f"Method: {method}")
+    logger.debug(f"Properties: {properties}")
+    logger.debug(f"Message: {body}")
+    logger.debug("****** Message processed successfully! Acking... ******")
+    amqp_client.ack_message_threadsafe(delivery_tag=method.delivery_tag)
+    logger.debug("****** Message acked successfully! ******")
+
+
+# Edit these lines to change the connection parameters
+protocol = "amqps"
+host = "[put-host-here]"
+port = "5671"
+user = "[put-user-here]"
+password = "[put-password-here]"
+# DON'T EDIT THE FOLLOWING LINES
+BROKER_URL = f"{protocol}://{user}:{password}@{host}:{port}"
+AMQP_QUEUE = "test-queue"
+is_dry_run = False
+logger = logging.getLogger(__name__)
+# The root logger handler that we have set up in settings is only set for log level of
+# "INFO" so if we want to override that, we need to add a new handler to this logger
+# so that we can give it a different log level
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
+logger.debug("============== STANDALONE SCRIPT DEBUG ==============")
+logger.debug("args: None cause I'm doing it myself")
+# Connect to AMQP Broker
+amqp_client = new_amqp_client()
+# Set up signal handlers since this script is intended to be run as its own process
+logger.debug("Setting up SIGINT/SIGTERM handler...")
+amqp_client.setup_signal_handlers()
+logger.debug(
+    f"Establishing connection to AMQP Broker on queue '{AMQP_QUEUE}'")
+with amqp_client as amqp_client:
+    amqp_client.consume(
+        AMQP_QUEUE,
+        receive_message,
+        auto_ack=False,
+        declare_queue=True)

--- a/examples/send_test.py
+++ b/examples/send_test.py
@@ -1,0 +1,21 @@
+from pika_multithreaded.clients import AmqpClient
+
+# Edit these lines to change the connection parameters
+protocol = "amqps"
+host = "[put-host-here]"
+port = "5671"
+queue = "test-queue"
+user = "[put-user-here]"
+password = "[put-password-here]"
+# DON'T EDIT THE FOLLOWING LINE
+url = f"{protocol}://{user}:{password}@{host}:{port}"
+
+print(">>> Creating connection object...")
+my_connection = AmqpClient(url=url)
+print(">>> Connection object created!")
+print(">>> Sending message...")
+my_connection.send_message(
+    routing_key="test-queue",
+    message="this is a test message. can you hear me???")
+
+print(">>> Message sent successfully!!! (maybe)")

--- a/pika_multithreaded/clients.py
+++ b/pika_multithreaded/clients.py
@@ -241,8 +241,6 @@ class AmqpClient:
         if not self.connection:
             auto_close_connection = True
         # =============================
-        if declare_queue:
-            self.queue_declare(queue, durable=True)
         keep_consuming = True
         self.user_consumer_callback = callback_function
         while keep_consuming:
@@ -252,6 +250,11 @@ class AmqpClient:
                     # This may occur when we're attempting to reconnect after a connection issue
                     self.logger.info(f"{'*'*20}\nConnecting...\n{'*'*20}")
                     self.connect()
+                # Queue declare is idempotent so it doesn't matter if we call it many times back to
+                # back. So if we're able to connect to the AMQP server, this guarantees there will
+                # be a queue available to consume
+                if declare_queue:
+                    self.queue_declare(queue, durable=True)
                 # Set QOS prefetch count. Now that this is multi-threaded, we can now control how
                 # many messages we process in parallel by simply increasing this number.
                 self.logger.debug(f"Setting QOS: {qos_count}...")

--- a/pika_multithreaded/clients.py
+++ b/pika_multithreaded/clients.py
@@ -9,6 +9,7 @@ from pika.exceptions import (
     ChannelWrongStateError)
 import signal
 import ssl
+import sys
 import threading
 import time
 import uuid
@@ -305,8 +306,8 @@ class AmqpClient:
     def _signal_handler(self, sig, frame):
         self.logger.warning(
             "*** AMQP Client terminating. Closing AMQP connection...")
-        self.stop_consuming()
         self.close()
+        sys.exit(0)
 
     def stop_consuming(self):
         if self.consumer_tag and self._is_connection_alive and self.channel.is_open:

--- a/pika_multithreaded/clients.py
+++ b/pika_multithreaded/clients.py
@@ -94,7 +94,9 @@ class AmqpClient:
         while True:
             try:
                 self.connection = pika.BlockingConnection(url_parameters)
+                self.logger.debug("Connected successfully! Creating channel...")
                 self.channel = self.connection.channel()
+                self.logger.debug("Channel created successfully!")
                 self._reconnect_delay = 0
                 break
             except (ProbableAuthenticationError,
@@ -251,12 +253,14 @@ class AmqpClient:
                     self.connect()
                 # Set QOS prefetch count. Now that this is multi-threaded, we can now control how
                 # many messages we process in parallel by simply increasing this number.
+                self.logger.debug(f"Setting QOS: {qos_count}...")
                 self.channel.basic_qos(prefetch_count=qos_count)
                 # Consume the queue
                 if consumer_tag:
                     self.consumer_tag = consumer_tag
                 else:
                     self.consumer_tag = f"pika-amqp-client-{str(uuid.uuid4())}"
+                self.logger.debug("Waiting for messages...")
                 self.channel.basic_consume(
                     queue,
                     self._consumer_callback,

--- a/pika_multithreaded/clients.py
+++ b/pika_multithreaded/clients.py
@@ -244,7 +244,6 @@ class AmqpClient:
         keep_consuming = True
         self.user_consumer_callback = callback_function
         while keep_consuming:
-            self.logger.debug(f"Connecting to queue {queue}...")
             try:
                 if not self.channel or self.channel.is_closed:
                     # This may occur when we're attempting to reconnect after a connection issue
@@ -264,7 +263,7 @@ class AmqpClient:
                     self.consumer_tag = consumer_tag
                 else:
                     self.consumer_tag = f"pika-amqp-client-{str(uuid.uuid4())}"
-                self.logger.debug("Waiting for messages...")
+                self.logger.debug(f"Waiting for messages on queue {queue}...")
                 self.channel.basic_consume(
                     queue,
                     self._consumer_callback,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open("README.md", "r") as file:
 
 setup(
     name='pika-multithreaded',
-    version='1.0.1',
+    version='1.1.0',
     author='Nimbis Services',
     author_email='info@nimbisservics.com',
     description='A project that enables multithreading support for the Pika package',


### PR DESCRIPTION
Network connections were supposed to be resilient such that if the AMQP connection got disconnected it reconnected. There was an error in this code that didn't allow it to re-connect. This fixes that issue and several other small bug fixes (like a io loop error when exiting a consumer).